### PR TITLE
Fix Safari download

### DIFF
--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -23,13 +23,6 @@ function fileSaver(url, name, format) {
         var blob;
         var objectUrl;
 
-        // Safari doesn't allow downloading of blob urls
-        if(Lib.isSafari()) {
-            var prefix = format === 'svg' ? ',' : ';base64,';
-            helpers.octetStream(prefix + encodeURIComponent(url));
-            return resolve(name);
-        }
-
         // IE 10+ (native saveAs)
         if(Lib.isIE()) {
             // At this point we are only dealing with a decoded SVG as


### PR DESCRIPTION
Fix for issue #1227.

It appears that the special code in fileSaver.js for handling Safari is actually causing the download of images to no longer work. I have simply removed the special logic there and downloads appear to work again in Safari Version 14.0.1 (16610.2.11.51.8).
